### PR TITLE
Fixes accessTokenExpires on initial signin

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -69,7 +69,7 @@ export default NextAuth({
       if (account && user) {
         return {
           accessToken: account.access_token,
-          accessTokenExpires: Date.now() + account.expires_in * 1000,
+          accessTokenExpires: account.expires_at * 1000,
           refreshToken: account.refresh_token,
           user
         }


### PR DESCRIPTION
On initial signin `account.expires_in` is undefined. The correct data is `account.expires_at`